### PR TITLE
Parameterize the GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A list of users who should _not_ be present on the server. The role will ensure 
 
 Whether the users' `authorized_keys` files should exclusively contain keys from their GitHub account. This should normally be set to `yes` if you are only allowing users to log in using keys available in their GitHub accounts.
 
+    github_url: https://github.com
+
+By default, use public GitHub (i.e. https://github.com) as the source for users/keys. Override this to use a different GitHub instance/endpoint (e.g. GitHub Enterprise).
+
 If you need to give the user the ability to self-manage their `authorized_keys` file, then you should set this to `no`, and it will only append new keys, but never remove any additional keys (e.g. old keys removed from their GitHub profile, or keys the end user added manually) from the file.
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,5 @@ github_users_absent: []
   # - geerlingguy
 
 github_users_authorized_keys_exclusive: yes
+
+github_url: https://github.com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Ensure authorized_keys for GitHub user accounts are present.
   authorized_key:
     user: "{{ item.name | default(item) }}"
-    key: "https://github.com/{{ item.name | default(item) }}.keys"
+    key: "{{ github_url }}/{{ item.name | default(item) }}.keys"
     manage_dir: yes
     exclusive: "{{ github_users_authorized_keys_exclusive }}"
   with_items: "{{ github_users }}"


### PR DESCRIPTION
This change exposes a `github_url` variable to allow users
to point this role against other GitHub instances (e.g. GitHub
Enterprise). By default, the value is still https://github.com.