### PR TITLE
Add shell optional property to github_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ None.
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
     github_users: []
-      # You can specify an object with 'name' (required) and 'groups' (optional):
+      # You can specify an object with 'name' (required), 'groups' (optional) and 'shell' (optional):
       # - name: geerlingguy
       #   groups: www-data,sudo
+      #   shell: /bin/bash
     
       # Or you can specify a GitHub username directly:
       # - geerlingguy
@@ -62,6 +63,9 @@ None.
           # Or if you don't need to override anything, you can specify the
           # GitHub username directly:
           - fabpot
+          # An user with a custom shell
+          - name: jon
+            shell: /bin/zsh
     
         github_users_absent:
           - johndoe

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Ensure GitHub user accounts are present.
   user:
     name: "{{ item.name | default(item) }}"
-    shell: /bin/bash
+    shell: "{{ item.shell | default('/bin/bash') }}"
     createhome: true
     groups: "{{ item.groups | default(omit) }}"
     home: /home/{{ item.name | default(item) }}


### PR DESCRIPTION
Set a custom shell for a user that I've added with this Ansible role.

**Example:**

```yaml
- hosts: servers

  vars:
    github_users:
      - name: geerlingguy
        shell: /bin/zsh
```