### PR TITLE
feat: Add optional machine_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Available variables are listed below, along with default values (see `defaults/m
       # You can specify an object with 'name' (required) and 'groups' (optional):
       # - name: geerlingguy
       #   groups: www-data,sudo
-    
+
       # Or you can specify a GitHub username directly:
       # - geerlingguy
 
@@ -29,7 +29,7 @@ A list of users to add to the server; the username will be the `name` (or the ba
     github_users_absent: []
       # You can specify an object with 'name' (required):
       # - name: geerlingguy
-    
+
       # Or you can specify a GitHub username directly:
       # - geerlingguy
 
@@ -52,7 +52,7 @@ None.
 ## Example Playbook
 
     - hosts: servers
-    
+
       vars:
         github_users:
           # You can specify the `name`:
@@ -62,11 +62,14 @@ None.
           # Or if you don't need to override anything, you can specify the
           # GitHub username directly:
           - fabpot
-    
+          # If you want a different machine_name
+          - name: geerlingguy
+            machine_name: foo
+
         github_users_absent:
           - johndoe
           - name: josh
-    
+
       roles:
         - geerlingguy.github-users
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 github_users: []
-# You can specify an object with 'name' (required) and 'groups' (optional):
+# You can specify an object with 'name' (required) and 'groups' (optional)
+# or a `machine_name` (optional) that is different from the GitHub username:
+# - name: geerlingguy
+#   groups: www-data,sudo
+#   machine_name: geerling
+
+# If no `machine_name` is used, the `name` will be used for the system user.
 # - name: geerlingguy
 #   groups: www-data,sudo
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 - name: Ensure GitHub user accounts are present.
   user:
-    name: "{{ item.name | default(item) }}"
+    name: "{{ item.machine_name | default(item.name | default(item)) }}"
     shell: /bin/bash
     createhome: true
     groups: "{{ item.groups | default(omit) }}"
-    home: /home/{{ item.name | default(item) }}
+    home: /home/{{ item.machine_name | default(item.name | default(item)) }}
     state: present
   with_items: "{{ github_users }}"
 
 - name: Ensure authorized_keys for GitHub user accounts are present.
   authorized_key:
-    user: "{{ item.name | default(item) }}"
+    user: "{{ item.machine_name | default(item.name | default(item)) }}"
     key: "{{ github_url }}/{{ item.name | default(item) }}.keys"
     manage_dir: true
     exclusive: "{{ github_users_authorized_keys_exclusive }}"
@@ -19,6 +19,6 @@
 
 - name: Ensure user accounts in github_users_absent are absent.
   user:
-    name: "{{ item.name | default(item) }}"
+    name: "{{ item.machine_name | default(item.name | default(item)) }}"
     state: absent
   with_items: "{{ github_users_absent }}"


### PR DESCRIPTION
Hi :wave: 

I'm a big fan, I thought maybe I could give a little something back for all that you have given us!

## Description

This adds an optional variable to specify a username on the machine that is different than the github username... in case you regret your github username choices.

It also looks like I found some trailing white-spaces... I can leave them in or rename `machine_name` if you like (maybe it is overloaded).

## Testing

I ran it locally...
<details><summary>Adding a test user</summary>

```yml
---
- name: "Local test"
  hosts: localhost
  connection: local
  become: true

  vars:
    github_users:
      - name: "MrKevinWeiss"
        machine_name: "test"
  roles:
    - my_custom_role_name
```

```
$ ansible-playbook hil-server.yml  -K
BECOME password: 
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost
does not match 'all'

PLAY [Local test] *********************************************************************

TASK [Gathering Facts] **********************************************************************************
ok: [localhost]

TASK [my_custom_role : Ensure GitHub user accounts are present.] ***********************************
ok: [localhost] => (item={'name': 'MrKevinWeiss', 'machine_name': 'test'})

TASK [my_custom_role: Ensure authorized_keys for GitHub user accounts are present.] ***************
changed: [localhost] => (item={'name': 'MrKevinWeiss', 'machine_name': 'test'})

TASK [my_custom_role : Ensure user accounts in github_users_absent are absent.] ********************
skipping: [localhost]

PLAY RECAP **********************************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   

```
</details>

<details><summary>removing the test user</summary>

```yml
---
- name: "Local test"
  hosts: localhost
  connection: local
  become: true

  vars:
    github_users_absent:
        machine_name: "test"
  roles:
    - my_custom_role_name
```

```
$ ansible-playbook hil-server.yml  -K
BECOME password: 
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost
does not match 'all'

PLAY [Local test] *********************************************************************

TASK [Gathering Facts] **********************************************************************************
ok: [localhost]

TASK [my_custom_role : Ensure GitHub user accounts are present.] ***********************************
skipping: [localhost]

TASK [my_custom_role : Ensure authorized_keys for GitHub user accounts are present.] ***************
skipping: [localhost]

TASK [my_custom_role : Ensure user accounts in github_users_absent are absent.] ********************
changed: [localhost] => (item={'machine_name': 'test'})

PLAY RECAP **********************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```
</details>