### PR TITLE
Make User Default Shell Configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ github_users: []
 # You can specify an object with 'name' (required) and 'groups' (optional):
 # - name: geerlingguy
 #   groups: www-data,sudo
+#   shell: /bin/zsh
 
 # Or you can specify a GitHub username directly:
 # - geerlingguy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Ensure GitHub user accounts are present.
   user:
     name: "{{ item.name | default(item) }}"
-    shell: /bin/bash
+    shell: "{{ item.shell | default('/bin/bash') }}"
     createhome: true
     groups: "{{ item.groups | default(omit) }}"
     home: /home/{{ item.name | default(item) }}


### PR DESCRIPTION
Hi @geerlingguy ,

thank you for all you awesome roles.

I would like to be able to set a custom shell (like /bin/zsh) and thought it might be worth to upstream the change :)

The default remains /bin/bash